### PR TITLE
Add regexp support

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="c75f5fa0-c1b2-43e7-8c04-171aae9e4db4" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/util/jsonpath/jsonpath_test.go" beforeDir="false" afterPath="$PROJECT_DIR$/util/jsonpath/jsonpath_test.go" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="GOROOT" url="file:///usr/local/Cellar/go/1.17.1/libexec" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GoLibraries">
+    <option name="indexEntireGoPath" value="false" />
+  </component>
+  <component name="KubernetesApiPersistence">
+    <option name="context" value="docker-desktop" />
+    <option name="namespace" value="default" />
+  </component>
+  <component name="ProjectId" id="2Adrjn7qXfaJ5KfL8XS0ntCfRGz" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="go.import.settings.migrated" value="true" />
+    <property name="go.sdk.automatically.set" value="true" />
+    <property name="go.tried.to.enable.integration.vgo.integrator" value="true" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="settings.editor.selected.configurable" value="preferences.pluginManager" />
+  </component>
+  <component name="RunManager" selected="Go Test.TestStructInput in k8s.io/client-go/util/jsonpath">
+    <configuration name="TestStructInput in k8s.io/client-go/util/jsonpath" type="GoTestRunConfiguration" factoryName="Go Test" temporary="true" nameIsGenerated="true">
+      <module name="client-go" />
+      <working_directory value="$PROJECT_DIR$/util/jsonpath" />
+      <root_directory value="$PROJECT_DIR$" />
+      <kind value="PACKAGE" />
+      <package value="k8s.io/client-go/util/jsonpath" />
+      <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
+      <framework value="gotest" />
+      <pattern value="^\QTestStructInput\E$" />
+      <method v="2" />
+    </configuration>
+    <configuration name="go test k8s.io/client-go/util/jsonpath" type="GoTestRunConfiguration" factoryName="Go Test" temporary="true" nameIsGenerated="true">
+      <module name="client-go" />
+      <working_directory value="$PROJECT_DIR$/util/jsonpath" />
+      <root_directory value="$PROJECT_DIR$" />
+      <kind value="PACKAGE" />
+      <package value="k8s.io/client-go/util/jsonpath" />
+      <directory value="$PROJECT_DIR$" />
+      <filePath value="$PROJECT_DIR$" />
+      <framework value="gotest" />
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Go Test.TestStructInput in k8s.io/client-go/util/jsonpath" />
+        <item itemvalue="Go Test.go test k8s.io/client-go/util/jsonpath" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VgoProject">
+    <integration-enabled>true</integration-enabled>
+  </component>
+</project>

--- a/util/jsonpath/jsonpath_test.go
+++ b/util/jsonpath/jsonpath_test.go
@@ -274,6 +274,14 @@ func TestStructInput(t *testing.T) {
 		{"recurarray", "{..Book[2]}", storeData,
 			`{"Category":"fiction","Author":"Herman Melville","Title":"Moby Dick","Price":8.99}`, false},
 		{"bool", "{.Bicycle[?(@.IsNew==true)]}", storeData, `{"Color":"red","Price":19.95,"IsNew":true}`, false},
+		{"regexp match get red bicycle", "{.Bicycle[?(@.Color=~'.*ed.*')]}", storeData, `{"Color":"red","Price":19.95,"IsNew":true}`, false},
+		{"regexp match get green bicycle", "{.Bicycle[?(@.Color=~'^g.*en.*')]}", storeData, `{"Color":"green","Price":20.01,"IsNew":false}`, false},
+		{"regexp match get all bicycle", "{.Bicycle[?(@.Color=~'.*e.*')]}", storeData, `{"Color":"red","Price":19.95,"IsNew":true} {"Color":"green","Price":20.01,"IsNew":false}`, false},
+
+		{"regexp match with bool is not supported", "{.Bicycle[?(@.IsNew=~'.*ue')]}", storeData, ``, true},
+		{"regexp match with number is not supported", "{.Bicycle[?(@.Price=~'.*95')]}", storeData, ``, true},
+
+
 	}
 
 	testJSONPath(storeTests, false, t)

--- a/util/jsonpath/parser.go
+++ b/util/jsonpath/parser.go
@@ -373,7 +373,7 @@ Loop:
 	if p.next() != ']' {
 		return fmt.Errorf("unclosed array expect ]")
 	}
-	reg := regexp.MustCompile(`^([^!<>=]+)([!<>=]+)(.+?)$`)
+	reg := regexp.MustCompile(`^([^!<>=]+)([!<>=~]+)(.+?)$`)
 	text := p.consumeText()
 	text = text[:len(text)-2]
 	value := reg.FindStringSubmatch(text)


### PR DESCRIPTION
Add regexp support to getting value form data.

Then you can use =~ to extarct value from data using regexp expression.

But it is only support string now.

Signed-off-by: yuzhipeng <yuzp1996@qq.com>

Sorry, we do not accept changes directly against this repository, unless the
change is to the `README.md` itself. Please see
`CONTRIBUTING.md` for information on where and how to contribute instead.
